### PR TITLE
Enable making tracing-subscriber an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,19 @@ aws-config = "0.52.0"
 aws-sdk-sqs = "0.22.0"
 clap = { version = "3.1.15", features = ["derive", "env"] }
 futures = "0.3.25"
-is-terminal = "0.4.3"
+is-terminal = {version = "0.4.3", optional = true }
 serde = "1.0"
 spin-core = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
 spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
 tokio = { version = "1.23", features = ["full"] }
 tokio-scoped = "0.2.0"
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.7", features = ["env-filter"], optional = true  }
 wasmtime = { version = "18.0.1" }
 
+[features]
+tracing-subscriber = ["dep:tracing-subscriber", "dep:is-terminal"]
+# By default, assume this project is used as a binary and a global tracing
+# subscriber should be set up. If this project is used as a library to a program
+# that already has a subscriber, the user can disable this feature.
+default = ["tracing-subscriber"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-
 use clap::Parser;
+#[cfg(feature = "tracing-subscriber")]
 use is_terminal::IsTerminal;
 use trigger_sqs::SqsTrigger;
 use spin_trigger::cli::TriggerExecutorCommand;
@@ -8,6 +8,8 @@ type Command = TriggerExecutorCommand<SqsTrigger>;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Conditionally initialize a tracing subscriber
+    #[cfg(feature = "tracing-subscriber")]
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())


### PR DESCRIPTION
The `tracing-subscriber` crate enables the `tracing-log` feature which will set up a global logger and panic if one already exists. If this project is consumed as a library a subscriber and logger may already exist and should not be reinitialized.