### PR TITLE
chore(*): Bump Spin dependency to v2.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.73
+          toolchain: 1.74
           targets: ${{ matrix.config.target }}
       - name: Install Spin
         uses: rajatjindal/setup-actions/spin@main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1470,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,7 +1986,7 @@ dependencies = [
  "hyper 0.14.27",
  "log",
  "rustls 0.20.9",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.23.4",
  "webpki-roots 0.22.6",
@@ -1968,12 +2001,27 @@ dependencies = [
  "futures-util",
  "http 0.2.11",
  "hyper 0.14.27",
- "log",
  "rustls 0.21.9",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.24.1",
- "webpki-roots 0.25.2",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c78f9338483cb7e630c8474b07268983c6bd5acee012e4211f9f7bb21b070"
+dependencies = [
+ "futures-util",
+ "http 0.2.11",
+ "hyper 0.14.27",
+ "log",
+ "rustls 0.22.3",
+ "rustls-native-certs 0.7.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -2249,10 +2297,11 @@ dependencies = [
 
 [[package]]
 name = "libsql"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43adbef635c87aaf72870e0a1a8cb39eefcc2c0b0386c75a9436ba6048548f07"
+checksum = "3879a4ed80a245fd4dd8c8fa139245653e86184ed3ab97a6d6ea592045d25793"
 dependencies = [
+ "async-stream",
  "async-trait",
  "base64 0.21.5",
  "bitflags 2.4.1",
@@ -2261,14 +2310,28 @@ dependencies = [
  "futures",
  "http 0.2.11",
  "hyper 0.14.27",
- "hyper-rustls 0.24.2",
+ "hyper-rustls 0.25.0",
+ "libsql-hrana",
  "libsql-sqlite3-parser",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-util 0.7.10",
  "tower",
  "tracing",
+]
+
+[[package]]
+name = "libsql-hrana"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f256c5c98e84808e067133253471d6f5961c670f0127150694210fb8e6116a"
+dependencies = [
+ "base64 0.21.5",
+ "bytes",
+ "prost",
+ "serde",
 ]
 
 [[package]]
@@ -2848,10 +2911,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 0.2.11",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.11",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float",
+ "percent-encoding",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -2886,14 +3045,15 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "http 0.2.11",
  "reqwest",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-locked-app",
  "spin-outbound-networking",
  "spin-world",
@@ -2903,9 +3063,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "outbound-mqtt"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+dependencies = [
+ "anyhow",
+ "rumqttc",
+ "spin-app",
+ "spin-core",
+ "spin-expressions",
+ "spin-outbound-networking",
+ "spin-world",
+ "table",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "outbound-mysql"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2913,6 +3090,7 @@ dependencies = [
  "mysql_common",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-outbound-networking",
  "spin-world",
  "table",
@@ -2923,14 +3101,15 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "native-tls",
  "postgres-native-tls",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-outbound-networking",
  "spin-world",
  "table",
@@ -2941,13 +3120,14 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "redis",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-outbound-networking",
  "spin-world",
  "table",
@@ -3236,6 +3416,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3496,7 +3699,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.9",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3542,6 +3745,25 @@ dependencies = [
  "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rumqttc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9"
+dependencies = [
+ "bytes",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.1.1",
+ "rustls-webpki 0.102.2",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "url",
 ]
 
 [[package]]
@@ -3662,8 +3884,22 @@ checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
 dependencies = [
  "log",
  "ring 0.17.5",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+dependencies = [
+ "log",
+ "ring 0.17.5",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3673,7 +3909,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -3688,12 +3937,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+dependencies = [
+ "base64 0.21.5",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.5",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring 0.17.5",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -4009,11 +4285,14 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin-app"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4028,8 +4307,8 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -4041,8 +4320,8 @@ dependencies = [
 
 [[package]]
 name = "spin-componentize"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "wasm-encoder 0.200.0",
@@ -4053,8 +4332,8 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4064,6 +4343,7 @@ dependencies = [
  "crossbeam-channel",
  "io-extras",
  "rustix 0.37.27",
+ "spin-telemetry",
  "system-interface",
  "tokio",
  "tracing",
@@ -4074,9 +4354,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-expressions"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "dotenvy",
+ "once_cell",
+ "serde",
+ "spin-locked-app",
+ "thiserror",
+]
+
+[[package]]
 name = "spin-key-value"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -4090,8 +4384,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-azure"
-version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "azure_data_cosmos",
@@ -4105,8 +4399,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-redis"
-version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "redis",
@@ -4119,8 +4413,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-sqlite"
-version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -4133,8 +4427,8 @@ dependencies = [
 
 [[package]]
 name = "spin-llm"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -4146,8 +4440,8 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "http 0.2.11",
@@ -4157,14 +4451,15 @@ dependencies = [
  "serde_json",
  "spin-core",
  "spin-llm",
+ "spin-telemetry",
  "spin-world",
  "tracing",
 ]
 
 [[package]]
 name = "spin-loader"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4201,8 +4496,8 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4215,8 +4510,8 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -4230,11 +4525,13 @@ dependencies = [
 
 [[package]]
 name = "spin-outbound-networking"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
+ "http 1.0.0",
  "ipnet",
+ "spin-expressions",
  "spin-locked-app",
  "terminal",
  "url",
@@ -4243,8 +4540,8 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "base64 0.21.5",
  "serde",
@@ -4252,8 +4549,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4266,8 +4563,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4281,8 +4578,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4295,9 +4592,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-telemetry"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+dependencies = [
+ "anyhow",
+ "http 0.2.11",
+ "http 1.0.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-appender",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "spin-trigger"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4308,6 +4624,7 @@ dependencies = [
  "indexmap 1.9.3",
  "ipnet",
  "outbound-http",
+ "outbound-mqtt",
  "outbound-mysql",
  "outbound-pg",
  "outbound-redis",
@@ -4318,6 +4635,7 @@ dependencies = [
  "spin-common",
  "spin-componentize",
  "spin-core",
+ "spin-expressions",
  "spin-key-value",
  "spin-key-value-azure",
  "spin-key-value-redis",
@@ -4344,8 +4662,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4354,6 +4672,7 @@ dependencies = [
  "serde",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-world",
  "thiserror",
  "tokio",
@@ -4362,8 +4681,8 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "wasmtime",
 ]
@@ -4513,8 +4832,8 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 
 [[package]]
 name = "tar"
@@ -4557,8 +4876,8 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "atty",
  "once_cell",
@@ -4683,9 +5002,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4765,6 +5084,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls 0.21.9",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.3",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -4862,6 +5192,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-trait",
+ "base64 0.21.5",
+ "bytes",
+ "http 0.2.11",
+ "http-body 0.4.5",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4902,6 +5253,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4934,6 +5297,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4943,12 +5334,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -5739,6 +6133,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5762,6 +6166,15 @@ name = "webpki-roots"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "whoami"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ clap = { version = "3.1.15", features = ["derive", "env"] }
 futures = "0.3.25"
 is-terminal = "0.4.3"
 serde = "1.0"
-spin-core = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
-spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
-tokio = { version = "1.23", features = ["full"] }
+spin-core = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
+spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
+tokio = { version = "1.37", features = ["full"] }
 tokio-scoped = "0.2.0"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@ use std::{sync::Arc, collections::HashMap};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use spin_trigger::{cli::NoArgs, TriggerAppEngine, TriggerExecutor, EitherInstance};
+use spin_trigger::{cli::NoArgs, TriggerAppEngine, TriggerExecutor};
+use spin_core::InstancePre;
 
 mod aws;
 mod utils;
@@ -69,6 +70,7 @@ impl TriggerExecutor for SqsTrigger {
     type RuntimeData = RuntimeData;
     type TriggerConfig = SqsTriggerConfig;
     type RunConfig = NoArgs;
+    type InstancePre = InstancePre<RuntimeData>;
 
     async fn new(engine: TriggerAppEngine<Self>) -> Result<Self> {
         let queue_components = engine
@@ -239,9 +241,6 @@ impl SqsMessageProcessor {
         let component_id = &self.component.id;
         tracing::trace!("Message {msg_id}: executing component {component_id}");
         let (instance, mut store) = self.engine.prepare_instance(component_id).await?;
-        let EitherInstance::Component(instance) = instance else {
-            unreachable!()
-        };
 
         let instance = SpinSqs::new(&mut store, &instance)?;
 


### PR DESCRIPTION
This commit bumps the Spin dependency to v2.4.0, and addresses the changes in
the trigger trait.

Signed-off-by: Radu Matei <radu@fermyon.com>
