### PR TITLE
feat(*): Add support for OTel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,17 +2152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi 0.3.3",
- "rustix 0.38.25",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5356,15 +5345,14 @@ dependencies = [
  "aws-sdk-sqs",
  "clap",
  "futures",
- "is-terminal",
  "openssl",
  "serde",
  "spin-core",
+ "spin-telemetry",
  "spin-trigger",
  "tokio",
  "tokio-scoped",
  "tracing",
- "tracing-subscriber",
  "wasmtime",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,13 @@ aws-config = "0.52.0"
 aws-sdk-sqs = "0.22.0"
 clap = { version = "3.1.15", features = ["derive", "env"] }
 futures = "0.3.25"
-is-terminal = "0.4.3"
 serde = "1.0"
 spin-core = { git = "https://github.com/fermyon/spin", tag = "v2.4.3" }
+spin-telemetry = { git = "https://github.com/fermyon/spin", tag = "v2.4.3" }
 spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.4.3" }
 tokio = { version = "1.37", features = ["full"] }
 tokio-scoped = "0.2.0"
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
 wasmtime = { version = "18.0.1" }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,25 @@
-
 use clap::Parser;
-use is_terminal::IsTerminal;
-use trigger_sqs::SqsTrigger;
 use spin_trigger::cli::TriggerExecutorCommand;
+use trigger_sqs::SqsTrigger;
 
 type Command = TriggerExecutorCommand<SqsTrigger>;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .with_ansi(std::io::stderr().is_terminal())
-        .init();
+    let _telemetry_guard = spin_telemetry::init(build_info())?;
 
     let t = Command::parse();
     t.run().await
+}
+
+/// Returns build information of the parent Spin process, similar to: 0.1.0 (2be4034 2022-03-31).
+fn build_info() -> String {
+    let spin_version = env_var("SPIN_VERSION");
+    let spin_commit_sha = env_var("SPIN_COMMIT_SHA");
+    let spin_commit_date = env_var("SPIN_COMMIT_DATE");
+    format!("{spin_version} ({spin_commit_sha} {spin_commit_date})")
+}
+
+fn env_var(name: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| "unknown".to_string())
 }


### PR DESCRIPTION
- Use spin_telemetry rather than setting up our own tracing subscriber.
- Parse the Spin version from the environment.
- Remove dependencies on is-terminal and tracing-subscriber (this unblocks SpinKube work)

Supersedes #18 