### PR TITLE
Update README to specify setting `AWS_DEFAULT_REGION` for example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ spin pluginify --install
 ## Test
 
 The trigger uses the AWS configuration environment variables - these must be set before running.
+Be sure to set `AWS_DEFAULT_REGION` in your environment to the region of your queue.
 
 You will also need to change the `queue_url` in `spin.toml` to a queue you have access to.
 


### PR DESCRIPTION
If not set, you get the following error:
```sh
2024-06-20T21:16:24.313175Z ERROR trigger_sqs: Queue https://sqs.us-west-2.amazonaws.com/177456779558/itowlsontest: error receiving messages: ConstructionFailure(ConstructionFailure { source: ResolveEndpointError { message: "no region in params", source: None } })
```