### PR TITLE
chore(build.yaml): pin macos amd64/aarch64 runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
         config:
           - { target: "x86_64-unknown-linux-gnu", os: "ubuntu-20.04", arch: "amd64", extension: ""}
           - { target: "aarch64-unknown-linux-gnu", os: "ubuntu-20.04", arch: "aarch64", extension: "", extraArg: "--features openssl/vendored" }
-          - { target: "x86_64-apple-darwin", os: "macos-latest", arch: "amd64", extension: "" }
-          - { target: "aarch64-apple-darwin", os: "macos-latest", arch: "aarch64", extension: "" }
+          - { target: "x86_64-apple-darwin", os: "macos-13", arch: "amd64", extension: "" }
+          - { target: "aarch64-apple-darwin", os: "macos-14", arch: "aarch64", extension: "" }
           - { target: "x86_64-pc-windows-msvc", os: "windows-latest", arch: "amd64", extension: ".exe" }
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- pin macos amd64 runner to macos-13 (macos-latest has switched to Apple Silicon)
- pin macos aarch64 runner to macos-14 (native build)