### PR TITLE
chore(spin-pluginify.toml): add description

### DIFF
--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -1,4 +1,5 @@
 name = "trigger-sqs"
+description = "A Spin trigger for Amazon SQS events"
 version = "0.7"
 spin_compatibility = ">=2.2"
 license = "Apache-2.0"


### PR DESCRIPTION
A description will be necessary to [pass plugin manifest validation](https://github.com/fermyon/spin-plugins?tab=readme-ov-file#validating-plugin-schemas) when we'd like to add this to the [spin-plugins](https://github.com/fermyon/spin-plugins) repo.

Please advise on ideal wording.