### PR TITLE
fix: update required rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trigger-sqs"
 version = "0.7.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.79"
 
 [dependencies]
 anyhow = "1.0.68"


### PR DESCRIPTION
follow up to https://github.com/fermyon/spin-trigger-sqs/pull/46#issuecomment-2353988091 to make sure required rust version is bumped