### PR TITLE
chore(Cargo.toml): bump to 0.8.0 for next release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "trigger-sqs"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trigger-sqs"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.79"
 

--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -1,6 +1,6 @@
 name = "trigger-sqs"
 description = "A Spin trigger for Amazon SQS events"
-version = "0.7"
+version = "0.8"
 spin_compatibility = ">=2.2"
 license = "Apache-2.0"
 package = "./target/release/trigger-sqs"


### PR DESCRIPTION
[diff](https://github.com/fermyon/spin-trigger-sqs/compare/v0.7.0...main)