### PR TITLE
Release v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5682,7 +5682,7 @@ dependencies = [
 
 [[package]]
 name = "trigger-sqs"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "aws-config 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trigger-sqs"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.81"
 

--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -1,6 +1,6 @@
 name = "trigger-sqs"
 description = "A Spin trigger for Amazon SQS events"
-version = "0.8"
+version = "0.8.1"
 spin_compatibility = ">=2.2"
 license = "Apache-2.0"
 package = "./target/release/trigger-sqs"


### PR DESCRIPTION
New release of the trigger that points to Spin v3.1.1 dependencies

Fulfills steps 1-3 of the [release process](https://github.com/fermyon/spin-trigger-sqs/blob/main/release-process.md)